### PR TITLE
Fixes bug where last encryption context is lost

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -56,7 +56,7 @@ class KeyValueToDictionary(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, 
                 self.dest, 
-                dict((x[0], x[1]) for x in values)
+                dict((x[0], x[1]) for x in values))
 
     
 def printStdErr(s):

--- a/credstash.py
+++ b/credstash.py
@@ -56,7 +56,7 @@ class KeyValueToDictionary(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, 
                 self.dest, 
-                dict((x[0], x[1]) for (x[0], x[1]) in [x for x in values]))
+                dict((x[0], x[1]) for x in values)
 
     
 def printStdErr(s):


### PR DESCRIPTION
The pre-python-2.7 replacement dictionary comprehension code strips the last encryption context
