### PR TITLE
make credstash install as a python module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         ],
     install_requires=['boto>=2.38.0', 'pycrypto>=2.6.1', 'PyYaml>=3.11'],
     scripts=['credstash.py'],
+    py_modules=['credstash'],
     entry_points={
         'console_scripts': [
             'credstash = credstash:main'


### PR DESCRIPTION
Small change to make credstash install as a single-file python module, allowing it to be imported.