### PR TITLE
Make PyYAML optional

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -25,7 +25,12 @@ import StringIO
 import sys
 import time
 import re
-import yaml
+
+try:
+    import yaml
+    NO_YAML=False
+except ImportError:
+    NO_YAML=True
 
 from base64 import b64encode, b64decode
 from boto.dynamodb2.exceptions import ConditionalCheckFailedException, ItemNotFound
@@ -250,7 +255,7 @@ def main():
     parsers[action] = subparsers.add_parser(action, help='Get all credentials from the store')
     parsers[action].add_argument("context", type=key_value_pair, action=KeyValueToDictionary, nargs='*', help="encryption context key/value pairs associated with the credential in the form of \"key=value\"")
     parsers[action].add_argument("-v", "--version", default="", help="Get a specific version of the credential (defaults to the latest version).")
-    parsers[action].add_argument("-f", "--format", default="json", choices=["json", "yaml", "csv"], help="Output format. json(default), yaml or csv.")
+    parsers[action].add_argument("-f", "--format", default="json", choices=["json", "csv"] + ([] if NO_YAML else ["yaml"]), help="Output format. json(default) " + ("" if NO_YAML else "yaml ") + "or csv.")
     parsers[action].set_defaults(action=action)
 
     action = 'list'
@@ -328,7 +333,7 @@ def main():
             output_args = {"sort_keys": True,
                            "indent": 4,
                            "separators": (',', ': ')}
-        elif args.format == "yaml":
+        elif not NO_YAML and args.format == "yaml":
             output_func = yaml.dump
             output_args = {"default_flow_style":False}
         elif args.format == 'csv':

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -3,4 +3,4 @@
 #      $ pip install -r optional-requirements.txt
 
 # In order to output `getall` in YAML format you need PyYAML
-PyYAML==3.11
+PyYAML==3.10

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,0 +1,6 @@
+# Optional Dependencies
+# To install, run:
+#      $ pip install -r optional-requirements.txt
+
+# In order to output `getall` in YAML format you need PyYAML
+PyYAML==3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 boto==2.38.0
 pycrypto==2.6.1
 wsgiref==0.1.2
-PyYAML==3.11

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: Apache Software License',
         ],
-    install_requires=['boto>=2.38.0', 'pycrypto>=2.6.1', 'PyYaml>=3.11'],
+    install_requires=['boto>=2.38.0', 'pycrypto>=2.6.1'],
+    extras_require = {'YAML': ['PyYAML>=3.10']},
     scripts=['credstash.py'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
As PyYAML uses distutils Extensions for libyaml bindings installation requires -devel packages and gcc.