### PR TITLE
fix for python 2.6 argparser

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -94,6 +94,9 @@ def expand_wildcard(string, secrets):
 
 
 def value_or_filename(string):
+    # argparse running on old version of python (<2.7) will pass an empty
+    # string to this function before it passes the actual value.
+    # If an empty string is passes in, just return an empty string
     if string == "":
         return ""
     if string[0] == "@":

--- a/credstash.py
+++ b/credstash.py
@@ -94,6 +94,8 @@ def expand_wildcard(string, secrets):
 
 
 def value_or_filename(string):
+    if string == "":
+        return ""
     if string[0] == "@":
         filename = string[1:]
         try:


### PR DESCRIPTION
on python 2.6, argparser calls `value_or_filename` with an empty string before it passes the `value` param to to `value_or_filename`. the index check blows up on an empty string. This fixes that.