### PR TITLE
make credstash python3 compatible by using boto3 kms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto==2.38.0
 pycrypto==2.6.1
 wsgiref==0.1.2
+boto3==1.1.1


### PR DESCRIPTION
using python3 with boto.kms breaks on decrypt/encrypt because of python3's handling of byte arrays