### PR TITLE
wsgiref==0.1.2 fails install on python3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 boto==2.38.0
 pycrypto==2.6.1
-wsgiref==0.1.2
 boto3==1.1.1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='credstash',
-    version='1.5',
+    version='1.5.1',
     description='A utility for managing secrets in the cloud using AWS KMS and DynamoDB',
     license='Apache2',
     url='https://github.com/LuminalOSS/credstash',


### PR DESCRIPTION
also, it doesn't appear to be used anywhere.